### PR TITLE
Update project assembly refs

### DIFF
--- a/ExamplePlugin/ExamplePlugin.csproj
+++ b/ExamplePlugin/ExamplePlugin.csproj
@@ -4,6 +4,11 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<LangVersion>preview</LangVersion>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+        <RestoreAdditionalProjectSources>
+			https://api.nuget.org/v3/index.json;
+			https://nuget.bepinex.dev/v3/index.json
+		</RestoreAdditionalProjectSources>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -18,8 +23,9 @@
 		<PackageReference Include="R2API.Language" Version="1.0.*" />
 
 		<PackageReference Include="UnityEngine.Modules" Version="2021.3.33" IncludeAssets="compile" />
-		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.9.0-r.0" />
-		<PackageReference Include="MMHOOK.RoR2" Version="2025.6.3" NoWarn="NU1701" />
+		<PackageReference Include="RiskOfRain2.GameLibs" Version="*-*" />
+		<PackageReference Include="MMHOOK.RoR2" Version="*" NoWarn="NU1701" />
+        <PackageReference Include="RoR2BepInExPack" Version="*" />
 	</ItemGroup>
 
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
- use wildcards for assembly references so that they are always latest ver which is easier for newcomers.
- Same for nuget.config extra project sources which is now handled directly in the csproj